### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/eik-lib/semantic-release-config.git"
+    "url": "git+https://github.com/eik-lib/semantic-release-config.git"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- replace the package repository metadata SSH URL with the public HTTPS GitHub URL
- keep runtime code, dependencies, exports, package version, homepage, bugs metadata, and license unchanged

## Why

`@eik/semantic-release-config@1.0.17` currently publishes:

```json
"repository": {
  "type": "git",
  "url": "git+ssh://git@github.com/eik-lib/semantic-release-config.git"
}
```

Because this is a public repository, package consumers and metadata tooling should be able to resolve the source repository without GitHub SSH credentials. The public `git+https://` form works in read-only environments.

## Validation

- `npm view @eik/semantic-release-config@1.0.17 name version repository homepage bugs license --json`
- `node -e "const p=require('./package.json'); if(p.repository.url!=='git+https://github.com/eik-lib/semantic-release-config.git') throw new Error('bad repository url'); if(p.bugs.url!=='https://github.com/eik-lib/semantic-release-config/issues') throw new Error('bugs changed'); if(p.homepage!=='https://github.com/eik-lib/semantic-release-config#readme') throw new Error('homepage changed'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage},null,2))"`
- `npm pack --dry-run --ignore-scripts --json .`
- `git diff --check`
